### PR TITLE
Fix a link in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This repo contains prebuilt versions of Google's Swappy Frame Pacing library.
 
 Compiled from source.
 
-See [Releases page](https://github.com/godotengine/godot-angle-static/releases).
+See [Releases page](https://github.com/godotengine/godot-swappy/releases).
 
 # How to build from source
 


### PR DESCRIPTION
The `Releases page` link used to direct to the `godot-angle-static` repository, this PR changes it to `godot-swappy`.
